### PR TITLE
`.readthedocs.yml`: Fix broken Python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.18"
+    python: "3.13"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Follow-up to #4 

Was supposed to read "3.8" originally in commit 2fa50ba351d2e90a97d23fbe04966213fc5d5193 but came out as "3.18" by accident. Now giving recent 3.13 a try.
